### PR TITLE
Fix IGC date parsing to support the new format.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,4 @@
-buildscript {
-    repositories {
-        maven { url 'https://maven.fabric.io/public' }
-    }
-
-    dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
-    }
-}
-
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
-
-repositories {
-    maven { url 'https://maven.fabric.io/public' }
-}
 
 android {
     compileSdkVersion 24
@@ -56,11 +41,6 @@ dependencies {
     compile 'com.google.android.gms:play-services-maps:10.0.1'
     compile 'org.greenrobot:eventbus:3.0.0'
     compile 'com.github.PhilJay:MPAndroidChart:v3.0.1'
-
-    compile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
-        transitive = true;
-    }
-
 
     compile fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {

--- a/app/src/main/java/com/shollmann/igcparser/IGCViewerApplication.java
+++ b/app/src/main/java/com/shollmann/igcparser/IGCViewerApplication.java
@@ -27,13 +27,9 @@ package com.shollmann.igcparser;
 import android.app.Application;
 import android.content.Context;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
 import com.shollmann.android.igcparser.model.IGCFile;
 import com.shollmann.android.igcparser.model.TaskConfig;
 import com.shollmann.igcparser.util.PreferencesHelper;
-
-import io.fabric.sdk.android.Fabric;
 
 public class IGCViewerApplication extends Application {
     private static IGCFile currentIGCFile;
@@ -54,11 +50,6 @@ public class IGCViewerApplication extends Application {
     }
 
     private void setupCrashlytics() {
-        Crashlytics crashlyticsKit = new Crashlytics.Builder()
-                .core(new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build())
-                .build();
-
-        Fabric.with(this, crashlyticsKit);
     }
 
     public Context getApplication() {

--- a/app/src/main/java/com/shollmann/igcparser/tracking/AnswersHelper.java
+++ b/app/src/main/java/com/shollmann/igcparser/tracking/AnswersHelper.java
@@ -24,12 +24,8 @@
 
 package com.shollmann.igcparser.tracking;
 
-import com.crashlytics.android.answers.Answers;
-import com.crashlytics.android.answers.CustomEvent;
-
 public class AnswersHelper {
 
     public static void trackEvent(String eventName){
-        Answers.getInstance().logCustom(new CustomEvent(eventName));
     }
 }

--- a/app/src/main/java/com/shollmann/igcparser/ui/activity/FlightInformationActivity.java
+++ b/app/src/main/java/com/shollmann/igcparser/ui/activity/FlightInformationActivity.java
@@ -38,7 +38,6 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
 import com.github.mikephil.charting.animation.Easing;
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.data.Entry;
@@ -81,7 +80,6 @@ public class FlightInformationActivity extends AppCompatActivity {
         if (igcFile != null) {
             showInformation();
         } else {
-            Crashlytics.log("FlightInformationActivity :: IGC File is null");
             Toast.makeText(getApplication().getBaseContext(), R.string.sorry_error_happen, Toast.LENGTH_SHORT).show();
             finish();
         }

--- a/app/src/main/java/com/shollmann/igcparser/ui/activity/FlightInformationActivity.java
+++ b/app/src/main/java/com/shollmann/igcparser/ui/activity/FlightInformationActivity.java
@@ -101,7 +101,7 @@ public class FlightInformationActivity extends AppCompatActivity {
     }
 
     private void showInformation() {
-        insertField(R.drawable.ic_calendar, R.string.date, igcFile.getDate());
+        insertField(R.drawable.ic_calendar, R.string.date, igcFile.getDate().toString());
         insertField(R.drawable.ic_person, R.string.pilot_in_charge, Utilities.capitalizeText(igcFile.getPilotInCharge()));
         insertField(R.drawable.ic_plane, R.string.glider, igcFile.getGliderTypeAndId());
         insertField(R.drawable.ic_speed, R.string.avg_speed, igcFile.getAverageSpeed() + "km/h");

--- a/app/src/main/java/com/shollmann/igcparser/ui/activity/FlightPreviewActivity.java
+++ b/app/src/main/java/com/shollmann/igcparser/ui/activity/FlightPreviewActivity.java
@@ -54,7 +54,6 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
@@ -266,8 +265,6 @@ public class FlightPreviewActivity extends AppCompatActivity implements OnMapRea
             try {
                 googleMap.addPolyline(polyline);
             } catch (Throwable t) {
-                Crashlytics.log("FlightPreviewActivity :: Tried to draw polyline when googleMap is null");
-                Crashlytics.logException(t);
             }
         }
 

--- a/app/src/main/java/com/shollmann/igcparser/ui/activity/IGCFilesActivity.java
+++ b/app/src/main/java/com/shollmann/igcparser/ui/activity/IGCFilesActivity.java
@@ -47,7 +47,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
 import com.shollmann.android.igcparser.Parser;
 import com.shollmann.android.igcparser.model.IGCFile;
 import com.shollmann.android.igcparser.util.Logger;
@@ -145,8 +144,6 @@ public class IGCFilesActivity extends AppCompatActivity implements MenuItem.OnMe
             Collections.sort(inFiles, Comparators.compareByDate);
         } catch (Throwable t) {
             final String message = "Couldn't open files";
-            Crashlytics.log(message);
-            Crashlytics.logException(t);
             Logger.logError(message);
         }
 
@@ -369,7 +366,6 @@ public class IGCFilesActivity extends AppCompatActivity implements MenuItem.OnMe
                 if (!isEntireFolder) {
                     final String message = "No IGC files found on XCSoar folder. Searching on other folders";
                     Logger.log(message);
-                    Crashlytics.log(message);
                     txtLoading.setText(getString(R.string.searching_igc_files));
                     new FindIGCFilesAsyncTask(activity.get()).execute(Utilities.getSdCardFolder());
                 } else {

--- a/app/src/main/java/com/shollmann/igcparser/ui/viewholder/FileViewHolder.java
+++ b/app/src/main/java/com/shollmann/igcparser/ui/viewholder/FileViewHolder.java
@@ -66,7 +66,7 @@ public class FileViewHolder extends RecyclerView.ViewHolder {
         txtFileName.setText(igcFile.getFileName());
         txtPilot.setText(Utilities.capitalizeText(igcFile.getPilotInCharge()));
         txtPilot.setVisibility(TextUtils.isEmpty(igcFile.getPilotInCharge()) ? View.GONE : View.VISIBLE);
-        txtDate.setText(igcFile.getDate());
+        txtDate.setText(igcFile.getDate().toString());
         txtGlider.setText(igcFile.getGliderTypeAndId());
         txtGlider.setVisibility(TextUtils.isEmpty(igcFile.getGliderTypeAndId()) ? View.GONE : View.VISIBLE);
     }

--- a/app/src/main/java/com/shollmann/igcparser/util/Comparators.java
+++ b/app/src/main/java/com/shollmann/igcparser/util/Comparators.java
@@ -28,7 +28,6 @@ import android.text.TextUtils;
 
 import com.shollmann.android.igcparser.model.IGCFile;
 
-import java.text.SimpleDateFormat;
 import java.util.Comparator;
 
 public class Comparators {
@@ -65,16 +64,9 @@ public class Comparators {
     };
 
     public static Comparator<IGCFile> compareByDate = new Comparator<IGCFile>() {
-        private SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy");
-
         @Override
         public int compare(IGCFile file0, IGCFile file1) {
-            try {
-                return sdf.parse(file1.getDate()).compareTo(sdf.parse(file0.getDate()));
-            } catch (Throwable t) {
-                return 0;
-            }
-
+            return file0.getDate().compareTo(file1.getDate());
         }
     };
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +17,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/igcParser/src/main/java/com/shollmann/android/igcparser/Parser.java
+++ b/igcParser/src/main/java/com/shollmann/android/igcparser/Parser.java
@@ -32,6 +32,7 @@ import android.text.TextUtils;
 import com.google.maps.android.SphericalUtil;
 import com.shollmann.android.igcparser.model.BRecord;
 import com.shollmann.android.igcparser.model.CRecordWayPoint;
+import com.shollmann.android.igcparser.model.IGCDate;
 import com.shollmann.android.igcparser.model.IGCFile;
 import com.shollmann.android.igcparser.util.Constants;
 import com.shollmann.android.igcparser.util.CoordinatesUtilities;
@@ -104,7 +105,7 @@ public class Parser {
                         }
 
                         if (isDateRecord(line)) {
-                            igcFile.setDate(parseDate(line));
+                            igcFile.setDate(new IGCDate(line));
                         }
                     }
                 }
@@ -182,7 +183,7 @@ public class Parser {
                     }
 
                     if (isDateRecord(line)) {
-                        igcFile.setDate(parseDate(line));
+                        igcFile.setDate(new IGCDate(line));
                     }
                 }
             }
@@ -207,19 +208,6 @@ public class Parser {
         }
         Logger.log(igcFile.toString());
         return igcFile;
-    }
-
-    private static String parseDate(String line) {
-        StringBuilder sb = new StringBuilder();
-        line = line.toUpperCase().replace(Constants.GeneralRecord.DATE, Constants.EMPTY_STRING);
-        try {
-            sb.append(line.substring(0, 2)).append(Constants.SLASH);
-            sb.append(line.substring(2, 4)).append(Constants.SLASH);
-            sb.append(line.substring(4));
-        } catch (Throwable t) {
-            Logger.logError("Unable to parse date");
-        }
-        return sb.toString();
     }
 
     @NonNull

--- a/igcParser/src/main/java/com/shollmann/android/igcparser/model/IGCDate.java
+++ b/igcParser/src/main/java/com/shollmann/android/igcparser/model/IGCDate.java
@@ -1,0 +1,88 @@
+package com.shollmann.android.igcparser.model;
+
+import android.support.annotation.NonNull;
+
+import com.crashlytics.android.Crashlytics;
+import com.shollmann.android.igcparser.util.Logger;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Models a date for an IGC track-log.
+ * Created by Thomas Fischer on 02/05/2021.
+ */
+public class IGCDate implements Comparable<IGCDate> {
+    /**
+     * Regular expression that matches encoded date strings as specified by the IGC data format.
+     * <p>
+     * There are two possible formats for the encoded date
+     * The original FAI-IGC FlightRecorder specification for the DTE record was 'HFDTE{DD}{MM}{YY}'
+     * while after the 2015/09 specification changes it became 'HFDTEDATE:{DD}{MM}{YY},{NN}'.
+     * Both formats are supported here.
+     * E.g. a date for the first flight on the 2nd of May 2021 would be encoded as 'HFDTE020521'
+     * or 'HFDTEDATE:020521,01' using the old and new formats respectively.
+     * <p>
+     * See: http://vali.fai-civl.org/faq.html
+     */
+    private static final Pattern pattern = Pattern.compile("(?:HFDTE(?:DATE:)?)(\\d{2}\\d{2}\\d{2})(?:,(\\d{2}))?");
+    private static final DateFormat dateFormatInput = new SimpleDateFormat("ddMMyy", Locale.getDefault());
+    private static final DateFormat dateFormatDisplay = new SimpleDateFormat("dd/MM/yyyy", Locale.getDefault());
+    private Date date;
+    private Integer flightNumber;
+
+    public IGCDate(String str) {
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            try {
+                date = dateFormatInput.parse(matcher.group(1));
+            } catch (ParseException e) {
+                e.printStackTrace();
+                String errorMessage = "IGCDate :: Unable to parse date string. Not a date.";
+                Logger.logError(errorMessage);
+                Crashlytics.log(errorMessage);
+                Crashlytics.logException(e);
+            }
+            try {
+                // Note: Flight number will be null for old format strings that don't specify it.
+                flightNumber = matcher.group(2) != null ? Integer.parseInt(matcher.group(2)) : null;
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+                String errorMessage = "IGCDate :: Unable to parse date string. Not a number.";
+                Logger.logError(errorMessage);
+                Crashlytics.log(errorMessage);
+                Crashlytics.logException(e);
+            }
+        } else {
+            String errorMessage = "IGCDate :: Unable to parse date string. Unexpected format.";
+            Logger.logError(errorMessage);
+            Crashlytics.log(errorMessage);
+        }
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public Integer getFlightNumber() {
+        return flightNumber;
+    }
+
+    @Override
+    public String toString() {
+        return dateFormatDisplay.format(date) +  (flightNumber == null ? "" : String.format(" %02d", flightNumber));
+    }
+
+    @Override
+    public int compareTo(@NonNull IGCDate igcDate) {
+        int result = date.compareTo(igcDate.date);
+        if (result != 0)
+            return result;
+        return flightNumber.compareTo(igcDate.flightNumber);
+    }
+}

--- a/igcParser/src/main/java/com/shollmann/android/igcparser/model/IGCDate.java
+++ b/igcParser/src/main/java/com/shollmann/android/igcparser/model/IGCDate.java
@@ -2,7 +2,6 @@ package com.shollmann.android.igcparser.model;
 
 import android.support.annotation.NonNull;
 
-import com.crashlytics.android.Crashlytics;
 import com.shollmann.android.igcparser.util.Logger;
 
 import java.text.DateFormat;
@@ -45,8 +44,6 @@ public class IGCDate implements Comparable<IGCDate> {
                 e.printStackTrace();
                 String errorMessage = "IGCDate :: Unable to parse date string. Not a date.";
                 Logger.logError(errorMessage);
-                Crashlytics.log(errorMessage);
-                Crashlytics.logException(e);
             }
             try {
                 // Note: Flight number will be null for old format strings that don't specify it.
@@ -55,13 +52,10 @@ public class IGCDate implements Comparable<IGCDate> {
                 e.printStackTrace();
                 String errorMessage = "IGCDate :: Unable to parse date string. Not a number.";
                 Logger.logError(errorMessage);
-                Crashlytics.log(errorMessage);
-                Crashlytics.logException(e);
             }
         } else {
             String errorMessage = "IGCDate :: Unable to parse date string. Unexpected format.";
             Logger.logError(errorMessage);
-            Crashlytics.log(errorMessage);
         }
     }
 

--- a/igcParser/src/main/java/com/shollmann/android/igcparser/model/IGCFile.java
+++ b/igcParser/src/main/java/com/shollmann/android/igcparser/model/IGCFile.java
@@ -48,7 +48,7 @@ public class IGCFile implements Serializable {
     private String pilotInCharge;
     private String gliderId;
     private String gliderType;
-    private String date;
+    private IGCDate date;
     private String fileName;
     private String filePath;
     private boolean isTaskCompleted;
@@ -152,11 +152,11 @@ public class IGCFile implements Serializable {
         this.pilotInCharge = pilotInCharge;
     }
 
-    public String getDate() {
+    public IGCDate getDate() {
         return date;
     }
 
-    public void setDate(String date) {
+    public void setDate(IGCDate date) {
         this.date = date;
     }
 

--- a/igcParser/src/test/java/com/shollmann/android/igcparser/IGCDateUnitTest.java
+++ b/igcParser/src/test/java/com/shollmann/android/igcparser/IGCDateUnitTest.java
@@ -1,0 +1,40 @@
+package com.shollmann.android.igcparser;
+
+import com.shollmann.android.igcparser.model.IGCDate;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class IGCDateUnitTest {
+
+    private static Date targetDate;
+
+    @Before
+    public void setUp() throws Exception {
+        targetDate = new SimpleDateFormat("dd/MM/yyyy").parse("02/05/2021");
+    }
+
+    @Test
+    public void parseOldFormat() {
+        String str = "HFDTE020521";
+        IGCDate igcDate = new IGCDate(str);
+
+        assertEquals(igcDate.getDate(), targetDate);
+        assertNull(igcDate.getFlightNumber());
+    }
+
+    @Test
+    public void parseNewFormat() {
+        String str = "HFDTEDATE:020521,01";
+        IGCDate igcDate = new IGCDate(str);
+
+        assertEquals(igcDate.getDate(), targetDate);
+        assertEquals(igcDate.getFlightNumber(), (Integer)1);
+    }
+}


### PR DESCRIPTION
Hi there! Fellow Argentinian and flight enthusiast here :) I've enjoyed your app so far but I was a bit annoyed that the track logs were not being shown in order, which I guessed was related to the parser not being able to cope with the new IGC date format as brought up in issue #65. I wrote a small patch that should allow for both the old and new date formats to be parsed properly. This in turn fixed the log display order.

BTW Not really related to this issue, but to be able to build your project on Android Studio 4.1.3 I had a few troubles.

1. From the quick looks of it, Fabric seems to have been taken over by Firebase for a while and does not seem to be compatible with the latest android SDK, so I just got rid of all the crashlytics references locally to get it working. On the same note, I don’t think the Setup -> Setup Fabric section of the README is relavant anymore.
2. Then I was greeted with the following message
```
Gradle sync failed: Unsupported method: SyncIssue.getMultiLineMessage().
The version of Gradle you connect to does not support that method.
To resolve the problem you can change/upgrade the target version of Gradle you connect to.
Alternatively, you can ignore this exception and read other information from the model.
```
Which I solved (following [this SO thread](https://github.com/udacity/ud839_Miwok/issues/215) by updating `build.gradle` to read
```
classpath 'com.android.tools.build:gradle:4.1.3'
```
﻿and `gradle-wrapper.properties` to
```
distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
```

Not really an Android or Java user, so let me know if you think something is in need of tuning.